### PR TITLE
Add sad path to destroy spec, fix table header format

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -1,5 +1,5 @@
 <h1><center>Books</h1></center>
-<table class="table table-striped">
+<div><table class="table table-striped">
   <thead class="thead-dark">
     <tr>
       <th scope="col">Title</th>
@@ -7,6 +7,8 @@
       <th scope="col">Publication Year</th>
       <th scope="col">Genre</th>
       <th scope="col">Summary</th>
+      <th scope="col"></th>
+      <th scope="col"></th>
     </tr>
   </thead>
   <tbody>
@@ -14,7 +16,6 @@
     <tr>
         <div id="book-<%= book.id%>">
         <th scope="row"><%= book.title %></th>
-        <div id="book-<%= book.id%>">
         <td><%= book.author %></td>
         <td><%= book.publication_year %></td>
         <td><%= book.genre %></td>
@@ -27,3 +28,4 @@
   </tbody>
 <p><%= button_to "Add Book", "/books/new", method: :get %></p>
 </table>
+</div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,7 +2,7 @@
 <html>
 <style>
     div{
-        padding-left:30px;
+        padding-left:25px;
     }
 </style>
   <head>

--- a/spec/features/destroy_spec.rb
+++ b/spec/features/destroy_spec.rb
@@ -3,7 +3,8 @@ require 'rails_helper'
 RSpec.describe 'destroy a book', type: :feature do 
     it 'can delete a book' do
         certain_hunger = Book.create!(title: "A Certain Hunger", publication_year: 2020, author: "Chelsea G. Summers", genre: "Horror", summary: "A food critic turns cannibal")
-        
+        roadside_picnic = Book.create!(title: "Roadside Picnic", publication_year: 1972, author: "Arkady Strugatsky", genre: "Sci-Fi", summary: "Alien invasion of small town in Russia")
+
         visit "/books"
 
         within "#book-#{certain_hunger.id}" do 
@@ -13,5 +14,6 @@ RSpec.describe 'destroy a book', type: :feature do
 
         expect(current_path).to eq("/books")
         expect(page).to_not have_content("A Certain Hunger")
+        expect(page).to have_content("Roadside Picnic")
     end
 end


### PR DESCRIPTION
Add sad path to destroy spec that was not previously working per Capybara, fix format for table header view. 